### PR TITLE
New features & bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,10 @@
 
 A Zig library to read/write an ini file using a struct.
 
-This library follows the Zig master branch. Check releases if you're using an old version.
+This library requires Zig >=0.12.0. Check releases if you're using an old version.
 
 ## Usage
 
 An example is provided in example/example.zig
 
 To run the example, just type: `zig build example`
-
-### Note
-
-When using writeFromStruct, only fields that differ from the default value will be written to the file.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.3.0",
     .dependencies = .{
         .ini = .{
-            .url = "https://github.com/ziglibs/ini/archive/da0af3a32e3403e3113e103767065cbe9584f505.tar.gz",
-            .hash = "1220d2557282a0362e5e58a4b53a7696220f85a41bf379f0c2b2b6e391a85972a514",
+            .url = "https://github.com/ziglibs/ini/archive/e8a2da707555c5afd2618ce48cda19e6f4c2b693.tar.gz",
+            .hash = "122063e0f311664963d32d09920fa7f09ba30087b4ed58d14dd3862610b87e4b2e72",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zigini",
-    .version = "0.2.3",
+    .version = "0.3.0",
     .dependencies = .{
         .ini = .{
             .url = "https://github.com/ziglibs/ini/archive/da0af3a32e3403e3113e103767065cbe9584f505.tar.gz",

--- a/example/example.zig
+++ b/example/example.zig
@@ -10,10 +10,10 @@ pub fn main() !void {
     var config_reader = zigini.Ini(Config).init(allocator);
     defer config_reader.deinit();
 
-    const config = try config_reader.readFileToStruct("example/config.ini");
+    const config = try config_reader.readFileToStruct("example/config.ini", null);
 
     std.debug.print("Writing ini file to stdout...\n\n", .{});
 
     const stdout = std.io.getStdOut();
-    try zigini.writeFromStruct(config, stdout.writer(), null);
+    try zigini.writeFromStruct(config, stdout.writer(), null, false, .{});
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,3 +1,2 @@
 pub const Ini = @import("reader.zig").Ini;
-pub const writeFromStructWithMap = @import("writer.zig").writeFromStructWithMap;
 pub const writeFromStruct = @import("writer.zig").writeFromStruct;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,2 +1,4 @@
-pub const Ini = @import("reader.zig").Ini;
+const reader = @import("reader.zig");
+pub const Ini = reader.Ini;
+pub const HandlerResult = reader.HandlerResult;
 pub const writeFromStruct = @import("writer.zig").writeFromStruct;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,4 @@
 const reader = @import("reader.zig");
 pub const Ini = reader.Ini;
-pub const HandlerResult = reader.HandlerResult;
+pub const IniField = reader.IniField;
 pub const writeFromStruct = @import("writer.zig").writeFromStruct;

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -19,14 +19,14 @@ else
     std.StaticStringMap(bool).initComptime(bool_string);
 
 pub const HandlerResult = struct {
-    changed: enum { key, value },
+    changed: enum { key, value, invalid },
     str: []const u8,
 };
 
 pub fn Ini(comptime T: type) type {
     return struct {
         const Self = @This();
-        const HandleIncorrectFieldFn = fn ([]const u8, []const u8) ?HandlerResult;
+        const TryMapFieldFn = fn ([]const u8, []const u8) ?HandlerResult;
 
         data: T,
         allocator: std.mem.Allocator,
@@ -76,13 +76,13 @@ pub fn Ini(comptime T: type) type {
                 self.allocator.free(utils.unwrapIfOptional(field.type, val));
         }
 
-        pub fn readFileToStruct(self: *Self, path: []const u8, comptime handle_incorrect_field_fn: ?HandleIncorrectFieldFn) !T {
+        pub fn readFileToStruct(self: *Self, path: []const u8, comptime try_map_field_fn: ?TryMapFieldFn, has_mapped_fields: ?*bool) !T {
             const file = try std.fs.cwd().openFile(path, .{});
             defer file.close();
-            return self.readToStruct(file.reader(), handle_incorrect_field_fn);
+            return self.readToStruct(file.reader(), try_map_field_fn, has_mapped_fields);
         }
 
-        pub fn readToStruct(self: *Self, reader: anytype, comptime handle_incorrect_field_fn: ?HandleIncorrectFieldFn) !T {
+        pub fn readToStruct(self: *Self, reader: anytype, comptime try_map_field_fn: ?TryMapFieldFn, has_mapped_fields: ?*bool) !T {
             var parser = ini.parse(self.allocator, reader);
             defer parser.deinit();
 
@@ -96,7 +96,7 @@ pub fn Ini(comptime T: type) type {
                         @memcpy(ns, heading);
                     },
                     .property => |kv| {
-                        try self.setStructVal(T, &self.data, kv, ns, handle_incorrect_field_fn);
+                        try self.setStructVal(T, &self.data, kv, ns, try_map_field_fn, has_mapped_fields);
                     },
                     .enumeration => {},
                 }
@@ -111,7 +111,8 @@ pub fn Ini(comptime T: type) type {
             data: *T1,
             kv: ini.KeyValue,
             ns: []const u8,
-            comptime handle_incorrect_field_fn: ?HandleIncorrectFieldFn,
+            comptime try_map_field_fn: ?TryMapFieldFn,
+            has_mapped_fields: ?*bool,
         ) !void {
             inline for (std.meta.fields(T1)) |field| {
                 const field_info = @typeInfo(field.type);
@@ -121,9 +122,10 @@ pub fn Ini(comptime T: type) type {
                     if (ns.len != 0) {
                         var namespace = ns;
 
-                        if (handle_incorrect_field_fn) |handle_incorrect_field| {
-                            const maybe_new_ns = @call(.always_inline, handle_incorrect_field, .{ ns, "" });
+                        if (try_map_field_fn) |try_map_field| {
+                            const maybe_new_ns = @call(.always_inline, try_map_field, .{ ns, "" });
                             if (maybe_new_ns) |new_ns| {
+                                if (has_mapped_fields) |ptr| ptr.* = new_ns.changed == .invalid or !std.ascii.eqlIgnoreCase(namespace, new_ns.str);
                                 namespace = new_ns.str;
                             }
                         }
@@ -136,7 +138,7 @@ pub fn Ini(comptime T: type) type {
                                     @field(data, field.name) = field_type{};
                             }
                             var inner_struct = utils.unwrapIfOptional(field.type, @field(data, field.name));
-                            try self.setStructVal(field_type, &inner_struct, kv, "", handle_incorrect_field_fn);
+                            try self.setStructVal(field_type, &inner_struct, kv, "", try_map_field_fn, has_mapped_fields);
                             @field(data, field.name) = inner_struct;
                         }
                     }
@@ -144,12 +146,15 @@ pub fn Ini(comptime T: type) type {
                     var key: []const u8 = kv.key;
                     var key_changed = false;
 
-                    if (handle_incorrect_field_fn) |handle_incorrect_field| {
-                        const maybe_new_key = @call(.always_inline, handle_incorrect_field, .{ kv.key, kv.value });
+                    if (try_map_field_fn) |try_map_field| {
+                        const maybe_new_key = @call(.always_inline, try_map_field, .{ kv.key, kv.value });
                         if (maybe_new_key) |new_key| {
                             if (new_key.changed == .key) {
+                                if (has_mapped_fields) |ptr| ptr.* = ptr.* or !std.ascii.eqlIgnoreCase(key, new_key.str);
                                 key = new_key.str;
                                 key_changed = true;
+                            } else if (new_key.changed == .invalid) {
+                                if (has_mapped_fields) |ptr| ptr.* = true;
                             }
                         }
                     }
@@ -158,9 +163,12 @@ pub fn Ini(comptime T: type) type {
                         var value: []const u8 = kv.value;
 
                         if (!key_changed) {
-                            if (handle_incorrect_field_fn) |handle_incorrect_field| {
-                                const maybe_new_value = @call(.always_inline, handle_incorrect_field, .{ kv.key, kv.value });
-                                if (maybe_new_value) |new_value| value = new_value.str;
+                            if (try_map_field_fn) |try_map_field| {
+                                const maybe_new_value = @call(.always_inline, try_map_field, .{ kv.key, kv.value });
+                                if (maybe_new_value) |new_value| {
+                                    if (has_mapped_fields) |ptr| ptr.* = ptr.* or !std.ascii.eqlIgnoreCase(value, new_value.str);
+                                    value = new_value.str;
+                                }
                             }
                         }
 
@@ -180,7 +188,7 @@ pub fn Ini(comptime T: type) type {
                         if (std.ascii.isASCII(char) and !std.ascii.isDigit(char))
                             return char;
                     }
-                    return std.fmt.parseInt(T1, val, 0) catch return error.InvalidValue;
+                    return try std.fmt.parseInt(T1, val, 0);
                 },
                 .Float => try std.fmt.parseFloat(T1, val),
                 .Bool => boolStringMap.get(val) orelse error.InvalidValue,

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -82,8 +82,14 @@ pub fn Ini(comptime T: type) type {
             return self.readToStruct(file.reader(), try_map_field_fn, has_mapped_fields);
         }
 
-        pub fn readToStruct(self: *Self, reader: anytype, comptime try_map_field_fn: ?TryMapFieldFn, has_mapped_fields: ?*bool) !T {
-            var parser = ini.parse(self.allocator, reader);
+        pub fn readToStruct(
+            self: *Self,
+            reader: anytype,
+            comment_characters: []const u8,
+            comptime try_map_field_fn: ?TryMapFieldFn,
+            has_mapped_fields: ?*bool,
+        ) !T {
+            var parser = ini.parse(self.allocator, reader, comment_characters);
             defer parser.deinit();
 
             var ns: []u8 = &.{};

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -78,10 +78,10 @@ pub fn Ini(comptime T: type) type {
                 self.allocator.free(utils.unwrapIfOptional(field.type, val));
         }
 
-        pub fn readFileToStruct(self: *Self, path: []const u8, comptime handler: ?FieldHandlerFn) !T {
+        pub fn readFileToStruct(self: *Self, path: []const u8, comment_characters: []const u8, comptime handler: ?FieldHandlerFn) !T {
             const file = try std.fs.cwd().openFile(path, .{});
             defer file.close();
-            return self.readToStruct(file.reader(), handler);
+            return self.readToStruct(file.reader(), comment_characters, handler);
         }
 
         pub fn readToStruct(self: *Self, reader: anytype, comment_characters: []const u8, comptime handler_opt: ?FieldHandlerFn) !T {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -37,7 +37,7 @@ test "Read ini without mapping" {
 
     var ini_conf = Ini(Config).init(std.testing.allocator);
     defer ini_conf.deinit();
-    const config = try ini_conf.readToStruct(fbs.reader(), null);
+    const config = try ini_conf.readToStruct(fbs.reader(), null, null);
 
     try std.testing.expectEqualStrings("Default String", config.string.?);
     try std.testing.expectEqualStrings("Another String", config.nt_string);
@@ -57,7 +57,7 @@ test "Read ini with mapping" {
     var ini_conf = Ini(Config).init(std.testing.allocator);
     defer ini_conf.deinit();
 
-    const config = try ini_conf.readToStruct(fbs.reader(), handleIncorrectConfigField);
+    const config = try ini_conf.readToStruct(fbs.reader(), handleIncorrectConfigField, null);
 
     try std.testing.expect(config.num == 33);
     try std.testing.expect(config.nested_config.num == 12);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -37,7 +37,7 @@ test "Read ini without mapping" {
 
     var ini_conf = Ini(Config).init(std.testing.allocator);
     defer ini_conf.deinit();
-    const config = try ini_conf.readToStruct(fbs.reader(), null, null);
+    const config = try ini_conf.readToStruct(fbs.reader(), ";#", null, null);
 
     try std.testing.expectEqualStrings("Default String", config.string.?);
     try std.testing.expectEqualStrings("Another String", config.nt_string);
@@ -57,7 +57,7 @@ test "Read ini with mapping" {
     var ini_conf = Ini(Config).init(std.testing.allocator);
     defer ini_conf.deinit();
 
-    const config = try ini_conf.readToStruct(fbs.reader(), handleIncorrectConfigField, null);
+    const config = try ini_conf.readToStruct(fbs.reader(), ";#", handleIncorrectConfigField, null);
 
     try std.testing.expect(config.num == 33);
     try std.testing.expect(config.nested_config.num == 12);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -15,9 +15,9 @@ const Config = struct {
     @"Other Config": ?NestedConfig = null,
 };
 
-fn handleIncorrectConfigField(key: []const u8, _: []const u8) ?[]const u8 {
-    if (std.mem.eql(u8, key, "Nested Config")) return "nested_config";
-    if (std.mem.eql(u8, key, "other")) return "num";
+fn handleIncorrectConfigField(key: []const u8, _: []const u8) ?ini.HandlerResult {
+    if (std.mem.eql(u8, key, "Nested Config")) return .{ .changed = .key, .str = "nested_config" };
+    if (std.mem.eql(u8, key, "other")) return .{ .changed = .key, .str = "num" };
 
     return null;
 }
@@ -37,7 +37,7 @@ test "Read ini without mapping" {
 
     var ini_conf = Ini(Config).init(std.testing.allocator);
     defer ini_conf.deinit();
-    const config = try ini_conf.readToStruct(fbs.reader());
+    const config = try ini_conf.readToStruct(fbs.reader(), null);
 
     try std.testing.expectEqualStrings("Default String", config.string.?);
     try std.testing.expectEqualStrings("Another String", config.nt_string);


### PR DESCRIPTION
This PR adds new features and fixes a couple bugs, though at the price of breaking the API (which is why I've upped the version to 0.3.0). This was made to accomodate for a better config migrator in Ly, though I've tried to make it as generic as possible. Here is the complete list of changes:

- Backport Zig 0.12.0 compilation support from v0.2.2
- Renamed `XwithMap` functions to just `X` and removed their "shorthand" versions (they didn't accomplish much, really)
- Added support for writing all fields from a struct via a new parameter in `writeFromStruct`
- Fixed writing `null` or booleans from a struct
- Added support for a field handler function as a parameter in `readToStruct` to map keys, namespaces and convert values where appropriate. This also removes the previous field string map